### PR TITLE
Fix truncation of server manager/operators

### DIFF
--- a/internal/pbsclient/client_test.go
+++ b/internal/pbsclient/client_test.go
@@ -359,4 +359,3 @@ func TestParseQmgrOutputWithTabContinuationLines(t *testing.T) {
 		t.Errorf("got %q, wanted %q", parsedOutput[0].attributes["log_events"], "511")
 	}
 }
-

--- a/internal/pbsclient/client_test.go
+++ b/internal/pbsclient/client_test.go
@@ -273,3 +273,90 @@ func TestGenerateUpdateAttributeCommand(t *testing.T) {
 		}
 	}
 }
+
+func TestParseQmgrOutputWithAppendOperator(t *testing.T) {
+	sourceText := `Server scheduler02
+    scheduling = True
+    acl_roots = root
+    managers = alice.smith@*
+    managers += bob.jones@*
+    managers += charlie.brown@*
+    managers += diana.prince@*
+    managers += eve.anderson@*
+    managers += frank.castle@*
+    managers += grace.hopper@*
+    managers += henry.ford@*`
+	parsedOutput := parseGenericQmgrOutput(sourceText)
+
+	if len(parsedOutput) != 1 {
+		t.Errorf("expected 1 output from parsing result but got %d", len(parsedOutput))
+		return
+	}
+	if parsedOutput[0].objType != "Server" {
+		t.Errorf("got %q, wanted %q", parsedOutput[0].objType, "Server")
+	}
+	if parsedOutput[0].name != "scheduler02" {
+		t.Errorf("got %q, wanted %q", parsedOutput[0].name, "scheduler02")
+	}
+	if len(parsedOutput[0].attributes) != 3 {
+		t.Errorf("expected 3 attributes but got %d", len(parsedOutput[0].attributes))
+	}
+	if val, ok := parsedOutput[0].attributes["scheduling"].(string); !ok || val != "True" {
+		t.Errorf("got %q, wanted %q", parsedOutput[0].attributes["scheduling"], "True")
+	}
+	if val, ok := parsedOutput[0].attributes["acl_roots"].(string); !ok || val != "root" {
+		t.Errorf("got %q, wanted %q", parsedOutput[0].attributes["acl_roots"], "root")
+	}
+
+	// The managers attribute should contain all values appended together with commas
+	expectedManagers := "alice.smith@*,bob.jones@*,charlie.brown@*,diana.prince@*,eve.anderson@*,frank.castle@*,grace.hopper@*,henry.ford@*"
+	if val, ok := parsedOutput[0].attributes["managers"].(string); !ok || val != expectedManagers {
+		t.Errorf("got %q, wanted %q", parsedOutput[0].attributes["managers"], expectedManagers)
+	}
+}
+
+func TestParseQmgrOutputWithTabContinuationLines(t *testing.T) {
+	// This tests the actual format that PBS uses when outputting long comma-separated values
+	// PBS uses tab characters for continuation lines, not spaces
+	sourceText := "Server pbs\n" +
+		"    scheduling = True\n" +
+		"    acl_roots = root\n" +
+		"    managers = abcdefgh@*,bcdefgha@*,cdefghab@*,defghabc@*,efghabcd@*,\n" +
+		"\tfghabcde@*,\n" +
+		"\tghabcdef@*,\n" +
+		"\thabcdefg@*\n" +
+		"    log_events = 511"
+
+	parsedOutput := parseGenericQmgrOutput(sourceText)
+
+	if len(parsedOutput) != 1 {
+		t.Errorf("expected 1 output from parsing result but got %d", len(parsedOutput))
+		return
+	}
+	if parsedOutput[0].objType != "Server" {
+		t.Errorf("got %q, wanted %q", parsedOutput[0].objType, "Server")
+	}
+	if parsedOutput[0].name != "pbs" {
+		t.Errorf("got %q, wanted %q", parsedOutput[0].name, "pbs")
+	}
+	if len(parsedOutput[0].attributes) != 4 {
+		t.Errorf("expected 4 attributes but got %d", len(parsedOutput[0].attributes))
+	}
+	if val, ok := parsedOutput[0].attributes["scheduling"].(string); !ok || val != "True" {
+		t.Errorf("got %q, wanted %q", parsedOutput[0].attributes["scheduling"], "True")
+	}
+	if val, ok := parsedOutput[0].attributes["acl_roots"].(string); !ok || val != "root" {
+		t.Errorf("got %q, wanted %q", parsedOutput[0].attributes["acl_roots"], "root")
+	}
+
+	// The managers attribute should contain all 8 values with proper comma separation
+	expectedManagers := "abcdefgh@*,bcdefgha@*,cdefghab@*,defghabc@*,efghabcd@*,fghabcde@*,ghabcdef@*,habcdefg@*"
+	if val, ok := parsedOutput[0].attributes["managers"].(string); !ok || val != expectedManagers {
+		t.Errorf("got %q, wanted %q", parsedOutput[0].attributes["managers"], expectedManagers)
+	}
+
+	if val, ok := parsedOutput[0].attributes["log_events"].(string); !ok || val != "511" {
+		t.Errorf("got %q, wanted %q", parsedOutput[0].attributes["log_events"], "511")
+	}
+}
+

--- a/internal/provider/server_resource_test.go
+++ b/internal/provider/server_resource_test.go
@@ -112,6 +112,7 @@ func TestAccServerResource_importAndUpdate(t *testing.T) {
 					resource.TestCheckResourceAttr("pbs_server.pbs", "max_array_size", "5000"),
 					resource.TestCheckResourceAttr("pbs_server.pbs", "node_fail_requeue", "600"),
 					resource.TestCheckResourceAttr("pbs_server.pbs", "eligible_time_enable", "true"),
+					resource.TestCheckResourceAttr("pbs_server.pbs", "managers", "abcdefgh@*,bcdefgha@*,cdefghab@*,defghabc@*,efghabcd@*,fghabcde@*,ghabcdef@*,habcdefg@*"),
 				),
 			},
 			// Update again with different values to test multiple updates
@@ -171,6 +172,7 @@ func testAccServerResourceConfigUpdated() string {
 resource "pbs_server" "pbs" {
   name                     = "pbs"
   comment                  = "Updated test server"
+	managers                 = "abcdefgh@*,bcdefgha@*,cdefghab@*,defghabc@*,efghabcd@*,fghabcde@*,ghabcdef@*,habcdefg@*"
   scheduler_iteration      = 300
   max_array_size           = 5000
   node_fail_requeue        = 600


### PR DESCRIPTION
Some string array attributes can present in qmgr output in multiple formats, this handles those by correctly processing += lines and lines starting with tab for continuation of previous line